### PR TITLE
Make json-error-error-face inherit from error

### DIFF
--- a/json-error.el
+++ b/json-error.el
@@ -30,11 +30,7 @@
   :group 'languages)
 
 (defface json-error-error-face
-  `((((class color) (background light))
-     (:foreground "red"))
-    (((class color) (background dark))
-     (:foreground "red"))
-    (t (:foreground "red")))
+  `((t (:inherit error)))
   "Face for JSON errors."
   :group 'json-error-mode)
 


### PR DESCRIPTION
The basic "error" face gives reasonable defaults, but more importantly
it is styled by most themes, so the user will get the error color they
are used to by default.

Fixes #1 